### PR TITLE
Update atom-erb.cson

### DIFF
--- a/keymaps/atom-erb.cson
+++ b/keymaps/atom-erb.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace':
+'.atom-workspace':
   'ctrl->': 'atom-erb:erb'


### PR DESCRIPTION
Updated deprecated .workspace selector to the new .atom-workspace selector.