### PR TITLE
Remove deprecated methods and syntax for Atom 1.0

### DIFF
--- a/keymaps/atom-erb.cson
+++ b/keymaps/atom-erb.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.atom-workspace':
+'atom-workspace':
   'ctrl->': 'atom-erb:erb'

--- a/lib/atom-erb.coffee
+++ b/lib/atom-erb.coffee
@@ -4,7 +4,7 @@ module.exports =
       "atom-erb:erb": => @erb()
 
   erb: ->
-    editor = atom.workspace.getActivePane().getActiveEditor()
+    editor = atom.workspace.getActiveTextEditor()
     editor.insertText("<%=  %>")
     [curr_r, curr_c] = editor.getCursorBufferPosition().toArray()
     editor.setCursorBufferPosition([curr_r, curr_c - 3])

--- a/lib/atom-erb.coffee
+++ b/lib/atom-erb.coffee
@@ -1,9 +1,10 @@
 module.exports =
   activate: (state) ->
-    atom.workspaceView.command "atom-erb:erb", => @erb()
+    atom.commands.add "atom-workspace",
+      "atom-erb:erb": => @erb()
 
   erb: ->
-    editor = atom.workspaceView.getActiveView().getEditor()
+    editor = atom.workspace.getActivePane().getActiveEditor()
     editor.insertText("<%=  %>")
     [curr_r, curr_c] = editor.getCursorBufferPosition().toArray()
     editor.setCursorBufferPosition([curr_r, curr_c - 3])

--- a/menus/atom-erb.cson
+++ b/menus/atom-erb.cson
@@ -1,7 +1,6 @@
 # See https://atom.io/docs/latest/creating-a-package#menus for more details
 'context-menu':
-  '.overlayer':
-      'Insert ERB Tag': 'atom-erb:erb'
+  '.overlayer': [{ 'Insert ERB Tag', command: 'atom-erb:erb'}]
 
 'menu': [
   {

--- a/package.json
+++ b/package.json
@@ -3,13 +3,9 @@
   "main": "./lib/atom-erb",
   "version": "0.1.0",
   "description": "A short description of your package",
-  "activationCommands": {
-    "atom-workspace": ["atom-erb:erb"]
-  },
   "repository": "https://github.com/aergonaut/atom-erb",
   "license": "MIT",
   "engines": {
-    "atom": ">0.50.0"
-  },
-  "dependencies": {}
+    "atom": ">=0.174.0 <2.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "main": "./lib/atom-erb",
   "version": "0.1.0",
   "description": "A short description of your package",
-  "activationEvents": [
-    "atom-erb:erb"
-  ],
+  "activationCommands": {
+    "atom-workspace": ["atom-erb:erb"]
+  },
   "repository": "https://github.com/aergonaut/atom-erb",
   "license": "MIT",
   "engines": {

--- a/spec/atom-erb-spec.coffee
+++ b/spec/atom-erb-spec.coffee
@@ -1,29 +1,36 @@
-{WorkspaceView} = require 'atom'
-AtomErb = require "../lib/atom-erb"
-
 # Use the command `window:run-package-specs` (cmd-alt-ctrl-p) to run specs.
 #
 # To run a specific `it` or `describe` block add an `f` to the front (e.g. `fit`
 # or `fdescribe`). Remove the `f` to unfocus the block.
 
 describe "AtomErb", ->
-  [editor, editorView, atomErb] = []
+  [editor, editorElement, workspaceElement] = []
 
   beforeEach ->
-    atom.workspaceView = new WorkspaceView
-    atom.workspace = atom.workspaceView.model
-    atom.workspaceView.openSync('test.erb')
-    editorView = atom.workspaceView.getActiveView()
-    {editor} = editorView
-    atomErb = AtomErb.activate()
-    editor.setCursorBufferPosition([0,0])
+    workspaceElement = atom.views.getView(atom.workspace)
 
-  describe "atom-erb:erb", ->
-    beforeEach ->
-      editorView.trigger "atom-erb:erb"
+    waitsForPromise ->
+      atom.workspace.open('test.erb')
 
-    it "inserts the ERB tag", ->
-      expect(editor.getText()).toEqual "<%=  %>"
+    runs ->
+      editor = atom.workspace.getActiveTextEditor()
+      editorElement = atom.views.getView(editor)
+      editor.setCursorBufferPosition([0,0])
 
-    it "moves the cursor inside the ERB tag", ->
-      expect(editor.getCursorBufferPosition().toArray()).toEqual [0,4]
+    waitsForPromise ->
+      atom.packages.activatePackage('atom-erb')
+
+  describe "atom-erb", ->
+    describe "activation", ->
+      it "should be in the packages list", ->
+        expect(atom.packages.loadedPackages["atom-erb"]).toBeDefined()
+
+    describe "atom-erb:erb", ->
+      beforeEach ->
+        atom.commands.dispatch workspaceElement, "atom-erb:erb"
+
+      it "inserts the ERB tag", ->
+        expect(editor.getText()).toEqual "<%=  %>"
+
+      it "moves the cursor inside the ERB tag", ->
+        expect(editor.getCursorBufferPosition().toArray()).toEqual [0,4]


### PR DESCRIPTION
Fixes #13. There are still deprecations within the package specs, but I have so far been unable to achieve passing specs with Atom 1.0 syntax. I'll open a separate PR for the specs if I achieve a passing suite.